### PR TITLE
Revert "feat(helm): update chart emqx-operator to 2.3.1"

### DIFF
--- a/kubernetes/main/apps/database/emqx/app/helmrelease.yaml
+++ b/kubernetes/main/apps/database/emqx/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: emqx-operator
-      version: 2.3.1
+      version: 2.2.29
       sourceRef:
         kind: HelmRepository
         name: emqx


### PR DESCRIPTION
Reverts qlonik/musical-parakeet#2390

This version of operator only works with new non-open-source versions of emqx